### PR TITLE
Use fixed version dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,11 +14,11 @@
     "node": ">=5.0.0"
   },
   "dependencies": {
-    "eslint": "^3.17.0",
-    "eslint-config-standard": "^7.0.0",
-    "eslint-plugin-standard": "^2.1.0",
-    "eslint-plugin-import": "^2.2.0",
-    "eslint-plugin-promise": "^3.5.0"
+    "eslint": "3.17.x",
+    "eslint-config-standard": "7.0.x",
+    "eslint-plugin-standard": "2.1.x",
+    "eslint-plugin-import": "2.2.x",
+    "eslint-plugin-promise": "3.5.x"
   },
   "devDependencies": {
     "mocha": "^3.0.0",


### PR DESCRIPTION
Dependencies now have fixed versions, allowing only patches. This will guarantee that the new rules will not break running tests for JavaScript projects.