### PR TITLE
v2.0.1 release

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+# Editor configuration
+.editorconfig
+
+# Travis CI setup
+.travis.yml
+
+# Current package's ESLint config
+.eslintrc.js
+
+# Tests
+*.test.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Medopad's ESLint configuration.",
   "keywords": ["eslint", "eslintconfig", "medopad"],
   "license": "MIT",


### PR DESCRIPTION
v2.0.1 release notes:

- No more support for Node v5 (only v6 and v7)
- Certain files are now ignored for the final package release
