### PR TITLE
v3.0.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Medopad's ESLint configuration.",
   "keywords": ["eslint", "eslintconfig", "medopad"],
   "license": "MIT",


### PR DESCRIPTION
v3.0.0 release notes:

- New mainstream library in use: `lodash`
- New rule: `max-len` (for 80 chars limit)
