### PR TITLE
Do not support Node v7 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ addons:
 language: node_js
 
 node_js:
-  - 7
   - 8
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=8.0.0",
+    "npm": ">=5.0.0"
   },
   "dependencies": {
     "eslint": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": ">=7.0.0"
+    "node": ">=8.0.0"
   },
   "dependencies": {
     "eslint": "^4.1.0",


### PR DESCRIPTION
We will currently be using Node v8 only. Also, npm v5 is required (due to locking of dependencies capability).