### PR TITLE
Ignore some lodash methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,17 @@ module.exports = {
     'lodash'
   ],
   rules: {
-    'max-len': 'error'
+    'max-len': 'error',
+    'lodash/prefer-lodash-method': [
+      'error',
+      {
+        'ignoreMethods': [
+          'filter',
+          'forEach',
+          'map',
+          'reduce'
+        ]
+      }
+    ]
   }
 }

--- a/index.test.js
+++ b/index.test.js
@@ -50,5 +50,21 @@ describe('Medopad\'s ESLint configuration', () => {
       code = `console.log('${crypto.randomBytes(33).toString('hex')}')\n`
       should(cli.executeOnText(code).errorCount).equal(1)
     })
+
+    it('should validate `lodash/prefer-lodash-method`', () => {
+      let code
+
+      code = `[].filter()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `[].forEach()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `[].map()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `[].reduce()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+    })
   })
 })


### PR DESCRIPTION
Currently it is mandatory using [lodash](https://lodash.com) over native implementation in many cases due to browser compatibility. However, we now allow the use of following methods natively:

- [filter](https://www.w3schools.com/jsref/jsref_filter.asp)
- [forEach](https://www.w3schools.com/jsref/jsref_foreach.asp)
- [map](https://www.w3schools.com/jsref/jsref_map.asp)
- [reduce](https://www.w3schools.com/jsref/jsref_reduce.asp)
