### PR TITLE
Ignore string lodash methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,10 @@ module.exports = {
           'filter',
           'forEach',
           'map',
-          'reduce'
+          'reduce',
+          'split',
+          'toLower',
+          'toUpper'
         ]
       }
     ]

--- a/index.test.js
+++ b/index.test.js
@@ -65,6 +65,15 @@ describe('Medopad\'s ESLint configuration', () => {
 
       code = `[].reduce()\n`
       should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `'a-b-c'.split('-')\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `'LONDON'.toLowerCase()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+
+      code = `'london'.toUpperCase()\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
     })
   })
 })


### PR DESCRIPTION
We now allow additional native string methods to be used natively:

- [split](https://www.w3schools.com/jsref/jsref_split.asp)
- [toLowerCase](https://www.w3schools.com/jsref/jsref_tolowercase.asp)
- [toUpperCase](https://www.w3schools.com/jsref/jsref_touppercase.asp)
