### PR TITLE
v3.6.0 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "eslint-config-standard": "^10.2.0",
     "eslint-plugin-import": "^2.7.0",
     "eslint-plugin-lodash": "^2.4.0",
-    "eslint-plugin-node": "^5.1.1",
+    "eslint-plugin-node": "^5.1.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-medopad",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Medopad's ESLint configuration.",
   "keywords": [
     "eslint",


### PR DESCRIPTION
v3.6.0 release notes:

- Adjusted rule `lodash/prefer-lodash-method` to allow using native string implementations of "split", "toLowerCase" and "toUpperCase"
