### PR TITLE
Do not force to use lodash's constant

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,6 +19,7 @@ module.exports = {
   ],
   rules: {
     'max-len': 'error',
+    'lodash/prefer-constant': 'off',
     'lodash/prefer-lodash-method': [
       'error',
       {

--- a/index.test.js
+++ b/index.test.js
@@ -51,6 +51,13 @@ describe('Medopad\'s ESLint configuration', () => {
       should(cli.executeOnText(code).errorCount).equal(1)
     })
 
+    it('should validate `lodash/prefer-constant`', () => {
+      let code
+
+      code = `module.exports = { pi: () => 3.1415 }\n`
+      should(cli.executeOnText(code).errorCount).equal(0)
+    })
+
     it('should validate `lodash/prefer-lodash-method`', () => {
       let code
 


### PR DESCRIPTION
New rule: `lodash/prefer-constant` off - will not force the use of lodash's constant.